### PR TITLE
makes categories optional (fixes #17)

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -7,6 +7,10 @@
 		{% include nav.html %}
 		<div id="content-left">
       <h2>Category: {{page.category}}</h2>
+      {% assign content = page.content | strip_newlines %}
+      {% if content != ""  %}
+        {{content}}
+      {% endif %}
       {% for post in site.categories[page.category] %}
         <div id="post-short">
           <a href="{{site.url}}{{site.baseurl}}{{post.url}}">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,13 +12,15 @@
         <p>
           {{ content }}
         </p>
-        <div id="categories">
-          <p><b>Categories:</b>&nbsp;
-            {% for category in page.categories %}
-              <a href="{{site.url}}{{site.baseurl}}/categories/{{category}}/">#{{category}}</a>&nbsp;
-            {% endfor %}
-          </p>
-        </div>
+        {% if page.categories.size > 0 %}
+          <div id="categories">
+            <p><b>Categories:</b>&nbsp;
+              {% for category in page.categories %}
+                <a href="{{site.url}}{{site.baseurl}}/categories/{{category}}/">#{{category}}</a>&nbsp;
+              {% endfor %}
+            </p>
+          </div>
+        {% endif %}
   		</div>
     </div>
 		{% include footer.html %}

--- a/categories/update.md
+++ b/categories/update.md
@@ -3,3 +3,4 @@ layout: category
 category: update
 permalink: /categories/update/
 ---
+This is an example description.


### PR DESCRIPTION
This PR makes given categories to a blog post optional.

If no category is provided the `Categories:` will no longer be shown.